### PR TITLE
doc(google ads source README): modeling to transform change 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This package models Google Ads data from [Fivetran's connector](https://fivetran
 
 ## Models
 
-This package contains staging models, designed to work simultaneously with our [Google Ads modeling package](https://github.com/fivetran/dbt_google_ads) and our [multi-platform Ad Reporting package](https://github.com/fivetran/dbt_ad_reporting).  The staging models name columns consistently across all packages:
+This package contains staging models, designed to work simultaneously with our [Google Ads transform package](https://github.com/fivetran/dbt_google_ads) and our [multi-platform Ad Reporting package](https://github.com/fivetran/dbt_ad_reporting).  The staging models name columns consistently across all packages:
  * Boolean fields are prefixed with `is_` or `has_`
  * Timestamps are appended with `_timestamp`
  * ID primary keys are prefixed with the name of the table. For example, the campaign table's ID column is renamed `campaign_id`.


### PR DESCRIPTION
Links https://fivetran.atlassian.net/browse/RD-190128

Changes mention of "transform package" into "modeling package."