### PR TITLE
update versions of depedencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_google_ads_source v0.9.4
+
+## Under the Hood:
+- Updates the dbt-expectations dependency to the latest version.
+- Updates the README to clarify why there exist differences among aggregations across different grains.
+
 # dbt_google_ads_source v0.9.3
 
 This release addresses a bug that was introduced via a grain change in the Google Ads connector `*_history` tables. This bug introduced duplicates and uniqueness test failures in staging `*_history` models ([PR #41](https://github.com/fivetran/dbt_google_ads_source/pull/41)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Under the Hood:
 - Updates the dbt-expectations dependency to the latest version.
-- Updates the README to clarify why there exist differences among aggregations across different grains.
+- Updates the DECISIONLOG to clarify why there exist differences among aggregations across different grains.
 
 # dbt_google_ads_source v0.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # dbt_google_ads_source v0.9.4
 
+[PR #45](https://github.com/fivetran/dbt_google_ads_source/pull/45) includes the following updates:
 ## Under the Hood:
-- Updates the dbt-expectations dependency to the latest version.
-- Updates the DECISIONLOG to clarify why there exist differences among aggregations across different grains.
+- Updates the [dbt-expectations](https://github.com/calogica/dbt-expectations/releases) dependency to the latest version.
+- Updates the [DECISIONLOG](DECISIONLOG.md) to clarify why there exist differences among aggregations across different grains.
 
 # dbt_google_ads_source v0.9.3
 

--- a/DECISIONLOG.md
+++ b/DECISIONLOG.md
@@ -3,3 +3,8 @@
 It was discovered within the source data that a single Ad can be associated with multiple ad groups on any given day. Because of this, it was determined that the `is_most_recent_record` logic within the `stg_google_ads__ad_history` model needed to account for the `ad_group_id` as well as the individual `ad_id`. As a result, the most recent record of an ad could possibly contain a unique combination of the `ad_id` and the `ad_group_id`.
 
 This logic was only applied to the `stg_google_ads__ad_history` model as it was discovered this relationship was unique to ads and ad groups. If you experience this relationship among any of the other ad hierarchies, please open and [issue](https://github.com/fivetran/dbt_google_ads_source/issues/new?assignees=&labels=bug%2Ctriage&template=bug-report.yml&title=%5BBug%5D+%3Ctitle%3E) and we can continue the discussion!
+
+## Why don't metrics add up across different grains (Ex. ad level vs campaign level)?
+Not all ads are served at the ad level. In other words, there are some ads that are served only at the ad group, campaign, etc. levels. The implications are that since not ads are included in the ad-level report, their associated spend, for example, won't be included at that grain. Therefore your spend totals may differ across the ad grain and another grain. 
+
+This is a reason why we have broken out the ad reporting packages into separate hierarchical end models (Ad, Ad Group, Campaign, and more). Because if we only used ad-level reports, we could be missing data.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ packages:
       version: [">=1.0.0", "<2.0.0"]
 
     - package: calogica/dbt_expectations
-      version: [">=0.8.0", "<0.9.0"]
+      version: [">=0.9.0", "<0.10.0"]
 
     - package: calogica/dbt_date
       version: [">=0.7.0", "<0.8.0"]

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'google_ads_source'
-version: '0.9.3'
+version: '0.9.4'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 vars:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'google_ads_source_integration_tests'
-version: '0.9.3'
+version: '0.9.4'
 profile: 'integration_tests'
 config-version: 2
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
 - package: calogica/dbt_expectations
-  version: [">=0.8.0", "<0.9.0"]
+  version: [">=0.9.0", "<0.10.0"]
 
 - package: fivetran/fivetran_utils
   version: [">=0.4.0", "<0.5.0"]


### PR DESCRIPTION
## PR Overview
**This PR will address the following Issue/Feature:**
https://github.com/fivetran/dbt_google_ads_source/issues/44
https://github.com/fivetran/dbt_google_ads_source/issues/39

**This PR will result in the following new package version:**
<!--- Please add details around your decision for breaking vs non-breaking version upgrade. If this is a breaking change, were backwards-compatible options explored? -->
v0.9.4

**Please detail what change(s) this PR introduces and any additional information that should be known during the review of this PR:**
- updates the dbt-expectations dependency version as there is now a v0.9.0
- adds clarifying documentation in the DECISION LOG about why customers may see differences in metric aggregations across different grains

## PR Checklist
### Basic Validation
Please acknowledge that you have successfully performed the following commands locally:
- [x] dbt compile
- [n/a] dbt run –full-refresh
- [x] dbt run
- [x] dbt test
- [ ] dbt run –vars (if applicable)

Before marking this PR as "ready for review" the following have been applied:
- [x] The appropriate issue has been linked and tagged
- [x] You are assigned to the corresponding issue and this PR
- [x] BuildKite integration tests are passing

### Detailed Validation
Please acknowledge that the following validation checks have been performed prior to marking this PR as "ready for review":
- [x] You have validated these changes and assure this PR will address the respective Issue/Feature.
- [x] You are reasonably confident these changes will not impact any other components of this package or any dependent packages.
- [x] You have provided details below around the validation steps performed to gain confidence in these changes.
<!--- Provide the steps you took to validate your changes below. -->
Run the google ads transforms with this branch
You'll need to add the following to the packages.yml:

```
  - git: https://github.com/fivetran/dbt_google_ads_source.git
    revision: update_deps_versions
    warn-unpinned: false
```


Run the ad reporting package with this branch
You'll need to add the following to the packages.yml:

```
  - git: https://github.com/fivetran/dbt_google_ads.git
    revision: minor_updates
    warn-unpinned: false
```


### Standard Updates
Please acknowledge that your PR contains the following standard updates:
- Package versioning has been appropriately indexed in the following locations:
    - [x] indexed within dbt_project.yml
    - [x] indexed within integration_tests/dbt_project.yml
- [x] CHANGELOG has individual entries for each respective change in this PR
    <!--- If there is a parallel upstream change, remember to reference the corresponding CHANGELOG as an individual entry.  -->
- [n/a] README updates have been applied (if applicable)
    <!--- Remember to check the following README locations for common updates. →
        <!--- Suggested install range (needed for breaking changes) →
        <!--- Dependency matrix is appropriately updated (if applicable) →
        <!--- New variable documentation (if applicable) -->
- [x] DECISIONLOG updates have been updated (if applicable)
- [ n/a] Appropriate yml documentation has been added (if applicable)

### ❗ Special Updates for Ad Reporting ❗
To reduce integration testing time, not all models should be enabled in the `run_models.sh` vars. Update the variables after `dbt run` and `dbt test` to set:
- [x] this PR's package to `true`
- [x] Google Ads and Facebook Ads to `true` (if not already)
- [x] All other packages to `false`S

### dbt Docs
Please acknowledge that after the above were all completed the below were applied to your branch:
- [n/a] docs were regenerated (unless this PR does not include any code or yml updates)

### If you had to summarize this PR in an emoji, which would it be?
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer:
