### PR TITLE
Update freshness config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/maintainer_pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/maintainer_pull_request_template.md
@@ -1,29 +1,35 @@
-## PR Overview
-**This PR will address the following Issue/Feature:**
+<!--
+Pre-Submission Reminders  
+Before marking this PR as "ready for review":
 
-**This PR will result in the following new package version:**
-<!--- Please add details around your decision for breaking vs non-breaking version upgrade. If this is a breaking change, were backwards-compatible options explored? -->
+- `dbt run --full-refresh && dbt test`  
+- `dbt run` && `dbt test` (if incremental models are present)  
+- The related issue is linked, tagged, and appropriately assigned  
+- Documentation and version updates are included, if applicable  
+- `docs` have been regenerated (unless there are no code or YAML changes)  
+- BuildKite integration tests are passing
+-->
 
-**Please provide the finalized CHANGELOG entry which details the relevant changes included in this PR:**
-<!--- Copy/paste the CHANGELOG for this version below. -->
+## PR Overview 
+**Package version introduced in this PR:** 
+ 
+**This PR addresses the following Issue/Feature(s):**
+<!-- Add Issue # or internal ticket reference -->
 
-## PR Checklist
-### Basic Validation
-Please acknowledge that you have successfully performed the following commands locally:
-- [ ] dbt run –full-refresh && dbt test
-- [ ] dbt run (if incremental models are present) && dbt test
+**Summary of changes:**  
+<!-- 1-2 sentences describing PR changes. -->
 
-Before marking this PR as "ready for review" the following have been applied:
-- [ ] The appropriate issue has been linked, tagged, and properly assigned
-- [ ] All necessary documentation and version upgrades have been applied
-- [ ] docs were regenerated (unless this PR does not include any code or yml updates)
-- [ ] BuildKite integration tests are passing
-- [ ] Detailed validation steps have been provided below
 
-### Detailed Validation
-Please share any and all of your validation steps:
-<!--- Provide the steps you took to validate your changes below. -->
+### Submission Checklist  
+- [ ] Alignment meeting with the reviewer (if needed)  
+  - [ ] Timeline and validation requirements discussed  
+- [ ] Provide validation details:  
+  - [ ] **Validation Steps:** Check for unintentional effects (e.g., add/run consistency & integrity tests)
+  - [ ] **Testing Instructions:** Confirm the change addresses the issue(s)
+  - [ ] **Focus Areas:** Complex logic or queries that need extra attention  
 
-### If you had to summarize this PR in an emoji, which would it be?
-<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
-:dancer:
+### Changelog  
+<!-- Recommend drafting changelog notes, then refining via ChatGPT using:  
+"Draft a changelog entry based on the following notes." -->
+- [ ] Draft changelog for PR  
+- [ ] Final changelog for release review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+# dbt_google_ads_source v0.14.0
+
+[PR #68](https://github.com/fivetran/dbt_google_ads_source/pull/68) includes the following updates:
+
+## Breaking Change for dbt Core < 1.9.5
+> *Note: This is not relevant to Fivetran Quickstart users.*
+
+Migrated `freshness` from a top-level source property to a source `config` in alignment with [recent updates](https://github.com/dbt-labs/dbt-core/issues/11506) from dbt Core. This will resolve the following deprecation warning that users running dbt >= 1.9.5 may have received:
+
+```
+[WARNING]: Deprecated functionality
+Found `freshness` as a top-level property of `google_ads` in file
+`models/src_google_ads.yml`. The `freshness` top-level property should be moved
+into the `config` of `google_ads`.
+```
+
+**IMPORTANT:** Users running dbt Core < 1.9.5 will not be able to utilize freshness tests in this release or any subsequent releases, as older versions of dbt will not recognize freshness as a source `config` and therefore not run the tests.
+
+If you are using dbt Core < 1.9.5 and want to continue running Google Ads freshness tests, please elect **one** of the following options:
+  1. (Recommended) Upgrade to dbt Core >= 1.9.5
+  2. Do not upgrade your installed version of the `google_ads_source` package. Pin your dependency on v0.13.0 in your `packages.yml` file.
+  3. Utilize a dbt [override](https://docs.getdbt.com/reference/resource-properties/overrides) to overwrite the package's `google_ads` source and apply freshness via the [old](https://github.com/fivetran/dbt_google_ads_source/blob/main/models/src_google_ads.yml#L11-L13) top-level property route. This will require you to copy and paste the entirety of the `src_google_ads.yml` [file](https://github.com/fivetran/dbt_google_ads_source/blob/main/models/src_google_ads.yml#L4-L327) and add an `overrides: google_ads_source` property.
+
+## Under the Hood
+- Updated the package maintainer PR template.
+
 # dbt_google_ads_source v0.13.0
 [PR #67](https://github.com/fivetran/dbt_google_ads_source/pull/67) introduces the following updates: 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 [PR #68](https://github.com/fivetran/dbt_google_ads_source/pull/68) includes the following updates:
 
-## Breaking Change for dbt Core < 1.9.5
+## Breaking Change for dbt Core < 1.9.6
 > *Note: This is not relevant to Fivetran Quickstart users.*
 
-Migrated `freshness` from a top-level source property to a source `config` in alignment with [recent updates](https://github.com/dbt-labs/dbt-core/issues/11506) from dbt Core. This will resolve the following deprecation warning that users running dbt >= 1.9.5 may have received:
+Migrated `freshness` from a top-level source property to a source `config` in alignment with [recent updates](https://github.com/dbt-labs/dbt-core/issues/11506) from dbt Core. This will resolve the following deprecation warning that users running dbt >= 1.9.6 may have received:
 
 ```
 [WARNING]: Deprecated functionality
@@ -14,10 +14,10 @@ Found `freshness` as a top-level property of `google_ads` in file
 into the `config` of `google_ads`.
 ```
 
-**IMPORTANT:** Users running dbt Core < 1.9.5 will not be able to utilize freshness tests in this release or any subsequent releases, as older versions of dbt will not recognize freshness as a source `config` and therefore not run the tests.
+**IMPORTANT:** Users running dbt Core < 1.9.6 will not be able to utilize freshness tests in this release or any subsequent releases, as older versions of dbt will not recognize freshness as a source `config` and therefore not run the tests.
 
-If you are using dbt Core < 1.9.5 and want to continue running Google Ads freshness tests, please elect **one** of the following options:
-  1. (Recommended) Upgrade to dbt Core >= 1.9.5
+If you are using dbt Core < 1.9.6 and want to continue running Google Ads freshness tests, please elect **one** of the following options:
+  1. (Recommended) Upgrade to dbt Core >= 1.9.6
   2. Do not upgrade your installed version of the `google_ads_source` package. Pin your dependency on v0.13.0 in your `packages.yml` file.
   3. Utilize a dbt [override](https://docs.getdbt.com/reference/resource-properties/overrides) to overwrite the package's `google_ads` source and apply freshness via the [old](https://github.com/fivetran/dbt_google_ads_source/blob/main/models/src_google_ads.yml#L11-L13) top-level property route. This will require you to copy and paste the entirety of the `src_google_ads.yml` [file](https://github.com/fivetran/dbt_google_ads_source/blob/main/models/src_google_ads.yml#L4-L327) and add an `overrides: google_ads_source` property.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - Materializes [Google Ads staging tables](https://fivetran.github.io/dbt_google_ads_source/#!/overview/google_ads_source/models/?g_v=1&g_e=seeds) which leverage data in the format described by [this ERD](https://fivetran.com/docs/applications/google-ads#schemainformation). These staging tables clean, test, and prepare your Google Ads data from [Fivetran's connector](https://fivetran.com/docs/applications/google-ads) for analysis by doing the following:
   - Name columns for consistency across all packages and for easier analysis
   - Adds freshness tests to source data
+    > dbt Core >= 1.9.5 is required to run freshness tests out of the box. See other options [here](https://github.com/fivetran/dbt_google_ads_source/blob/main/CHANGELOG.md#breaking-change-for-dbt-core--195).
   - Adds column-level testing where applicable. For example, all primary keys are tested for uniqueness and non-null values.
 - Generates a comprehensive data dictionary of your google_ads data through the [dbt docs site](https://fivetran.github.io/dbt_google_ads_source/).
 - These tables are designed to work simultaneously with our [Google Ads transformation package](https://github.com/fivetran/dbt_google_ads).
@@ -41,7 +42,7 @@ If you  are **not** using the [Google Ads transformation package](https://github
 ```yml
 packages:
   - package: fivetran/google_ads_source
-    version: [">=0.13.0", "<0.14.0"] # we recommend using ranges to capture non-breaking changes automatically
+    version: [">=0.14.0", "<0.15.0"] # we recommend using ranges to capture non-breaking changes automatically
 ```
 ### Step 3: Define database and schema variables
 By default, this package runs using your destination and the `google_ads` schema. If this is not where your Google Ads data is (for example, if your google_ads schema is named `google_ads_fivetran`), add the following configuration to your root `dbt_project.yml` file:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - Materializes [Google Ads staging tables](https://fivetran.github.io/dbt_google_ads_source/#!/overview/google_ads_source/models/?g_v=1&g_e=seeds) which leverage data in the format described by [this ERD](https://fivetran.com/docs/applications/google-ads#schemainformation). These staging tables clean, test, and prepare your Google Ads data from [Fivetran's connector](https://fivetran.com/docs/applications/google-ads) for analysis by doing the following:
   - Name columns for consistency across all packages and for easier analysis
   - Adds freshness tests to source data
-    > dbt Core >= 1.9.5 is required to run freshness tests out of the box. See other options [here](https://github.com/fivetran/dbt_google_ads_source/blob/main/CHANGELOG.md#breaking-change-for-dbt-core--195).
+    > dbt Core >= 1.9.6 is required to run freshness tests out of the box. See other options [here](https://github.com/fivetran/dbt_google_ads_source/blob/main/CHANGELOG.md#breaking-change-for-dbt-core--196).
   - Adds column-level testing where applicable. For example, all primary keys are tested for uniqueness and non-null values.
 - Generates a comprehensive data dictionary of your google_ads data through the [dbt docs site](https://fivetran.github.io/dbt_google_ads_source/).
 - These tables are designed to work simultaneously with our [Google Ads transformation package](https://github.com/fivetran/dbt_google_ads).

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'google_ads_source'
-version: '0.13.0'
+version: '0.14.0'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 vars:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'google_ads_source_integration_tests'
-version: '0.13.0'
+version: '0.14.0'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/src_google_ads.yml
+++ b/models/src_google_ads.yml
@@ -8,12 +8,12 @@ sources:
     loader: Fivetran
     loaded_at_field: _fivetran_synced
 
-    freshness: 
-      warn_after: {count: 48, period: hour}
-      error_after: {count: 168, period: hour}
     config:
-          enabled: "{{ var('ad_reporting__google_ads_enabled', true) }}"
-
+      enabled: "{{ var('ad_reporting__google_ads_enabled', true) }}"
+      freshness: 
+        warn_after: {count: 48, period: hour}
+        error_after: {count: 168, period: hour}
+      
     tables:
       - name: ad_stats
         description: Each record represents the daily performance of an ad in Google Ads broken down to the ad network, device type, and ad group criterion.


### PR DESCRIPTION
<!--
Pre-Submission Reminders  
Before marking this PR as "ready for review":

- `dbt run --full-refresh && dbt test`  
- `dbt run` && `dbt test` (if incremental models are present)  
- The related issue is linked, tagged, and appropriately assigned  
- Documentation and version updates are included, if applicable  
- `docs` have been regenerated (unless there are no code or YAML changes)  
- BuildKite integration tests are passing
-->

## PR Overview 
**Package version introduced in this PR:** 
 v0.14.0

**This PR addresses the following Issue/Feature(s):**
<!-- Add Issue # or internal ticket reference -->
https://github.com/fivetran/dbt_ad_reporting/issues/148

**Summary of changes:**  
<!-- 1-2 sentences describing PR changes. -->
Updates freshness to align with the new config framework introduced in dbt Core v1.9. Documents how users on older versions of dbt Core will/can interface with freshness

### Submission Checklist  
- [ ] Alignment meeting with the reviewer (if needed)  
  - [ ] Timeline and validation requirements discussed  
- [ ] Provide validation details:  
  - [x] **Validation Steps:** Check for unintentional effects (e.g., add/run consistency & integrity tests)

older versions of dbt do not run freshness tests, but there's no error message
![image](https://github.com/user-attachments/assets/54ff5dd0-ab0d-4b9f-b6fd-e11b7d2ec19f)

Also I adjusted the indenting of the `config.enabled` property -- when I disable google_ads, the variable still gets picked up and `dbt source freshness` and `dbt run` appropriately produce nothing
![image](https://github.com/user-attachments/assets/2ee1c443-1beb-449d-a73c-590b13185447)

  - [x] **Testing Instructions:** Confirm the change addresses the issue(s)
freshness tests are running on dbt 1.9.5+
![image](https://github.com/user-attachments/assets/5e801e6c-8b9e-465b-863d-e3f98e077e46)

  - [ ] **Focus Areas:** Complex logic or queries that need extra attention  

### Changelog  
<!-- Recommend drafting changelog notes, then refining via ChatGPT using:  
"Draft a changelog entry based on the following notes." -->
- [x] Draft changelog for PR  
- [ ] Final changelog for release review